### PR TITLE
update install Readme.md - pipenv egg=pysigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ poetry add git+https://github.com/SigmaHQ/pySigma.git#main
 **Pipenv:**
 
 ```bash
-pipenv install git+https://github.com/SigmaHQ/pySigma.git#main
+pipenv install git+https://github.com/SigmaHQ/pySigma.git#egg=pysigma
 ```
 
 ## Features


### PR DESCRIPTION
pysigma was failing to install on OSX ... I had to use the following command to get it to work

pipenv install git+https://github.com/SigmaHQ/pySigma.git#egg=pysigma

I then noticed [others had the same issue #15](https://github.com/SigmaHQ/pySigma/issues/15) on Ubuntu 

Here's a pull request to fix install for at least Ubuntu/OSX